### PR TITLE
Fixes for node v0.8 and for when content-type is set using resp.setHeader.

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,6 +42,7 @@ module.exports = function(subFunc) {
     var realWrite = resp.write;
     var realEnd = resp.end;
     var realWriteHead = resp.writeHead;
+    var realSetHeader = resp.setHeader;
 
     var buf = undefined;
     var enc = undefined;
@@ -78,6 +79,11 @@ module.exports = function(subFunc) {
       if (encoding) enc = encoding;
     };
 
+    resp.setHeader = function(name, value) {
+      if (name.toLowerCase() === 'content-type') contentType = value;
+      realSetHeader.call(resp, name, value);
+    };
+
     resp.end = function(body) {
       if (!buf && body) buf = body;
       if (!contentType) contentType = resp.getHeader('content-type');
@@ -96,7 +102,7 @@ module.exports = function(subFunc) {
         realWrite.call(resp, buf, enc);
       }
       realEnd.call(resp);
-    }
+    };
 
     next();
   };

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
   },
   "devDependencies": {
-    "should": "0.5.1",
+    "should": "1.2.2",
     "mocha": "0.12.0",
     "express": "2.5.8",
     "buffertools": "1.0.7"

--- a/test/test.js
+++ b/test/test.js
@@ -86,12 +86,20 @@ describe('postprocess', function() {
     });
   });
 
+  it('should not interfere with the semantics of setHeader()', function(done) {
+    get('/write_strings', function(err, r) {
+      should(err === null);
+      r.res.headers['content-type'].should.equal('text/plain');
+      done();
+    });
+  });
+
   it('should not interfere with the semantics of end()', function(done) {
     get('/end_string', function(err, r) {
       should(err === null);
       r.data.should.equal('barbar');
     });
-    
+
     get('/end_buffer', function (err,r) {
       should(err === null);
       r.data.should.equal('barbar');


### PR DESCRIPTION
- Use should v1.2.2 which is compatible with newer nodes.
- Add a resp.setHeader proxy which sets the content-type if set from there.

fixes #1
fixes #2
